### PR TITLE
Improve phpstan docblock for Arrays::mapAssoc

### DIFF
--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -118,12 +118,13 @@ class Arrays
      *      // output: [1 => false, 2 => true, 3 => false]
      * </code>
      * @template T
+     * @template V
      * @template K of int|string
      *
      * @param T[]                              $items
-     * @param (callable(T): array{0: K, 1: T}) $callback
+     * @param (callable(T): array{0: K, 1: V}) $callback
      *
-     * @return array<K, T>
+     * @return array<K, V>
      */
     public static function mapAssoc(array $items, callable $callback): array
     {

--- a/tests/Unit/ArraysTest.php
+++ b/tests/Unit/ArraysTest.php
@@ -61,7 +61,7 @@ class ArraysTest extends TestCase
 
         static::assertSame([], Arrays::mapAssoc([], $callback));
         static::assertSame(['foo' => 'bar'], Arrays::mapAssoc([['foo', 'bar']], $callback));
-        static::assertSame([2 => false, 4 => true, 6 => false], Arrays::mapAssoc([1, 2, 3], static fn(int $val) => [$val, $val % 2 === 0]));
+        static::assertSame([2 => false, 4 => true, 6 => false], Arrays::mapAssoc([1, 2, 3], static fn(int $val) => [$val * 2, $val % 2 === 0]));
     }
 
     public function testReindex(): void

--- a/tests/Unit/ArraysTest.php
+++ b/tests/Unit/ArraysTest.php
@@ -61,6 +61,7 @@ class ArraysTest extends TestCase
 
         static::assertSame([], Arrays::mapAssoc([], $callback));
         static::assertSame(['foo' => 'bar'], Arrays::mapAssoc([['foo', 'bar']], $callback));
+        static::assertSame([2 => false, 4 => true, 6 => false], Arrays::mapAssoc([1, 2, 3], static fn(int $val) => [$val, $val % 2 === 0]));
     }
 
     public function testReindex(): void


### PR DESCRIPTION
In the Arrays::mapAssoc method, the `T` isn't necessarily expected as return value. Changed it to separate `V` template.