### PR TITLE
Add get_debug_type to assert failure message

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -308,6 +308,8 @@ class Assert
 
     private static function createException(string $expectedType, mixed $value): RuntimeException
     {
-        return new RuntimeException(sprintf('Expecting value to be %s, `%s` was given', $expectedType, get_debug_type($value)));
+        $type = is_bool($value) ? ($value ? 'true' : 'false') : get_debug_type($value);
+
+        return new RuntimeException(sprintf('Expecting value to be %s, `%s` was given', $expectedType, $type));
     }
 }

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -28,7 +28,7 @@ class Assert
     public static function null(mixed $value): mixed
     {
         if ($value !== null) {
-            throw new RuntimeException('Expecting value to be null');
+            throw self::createException('null', $value);
         }
 
         return null;
@@ -39,14 +39,14 @@ class Assert
      * @template       T
      * @phpstan-assert !null $value
      *
-     * @param T|null $value
+     * @param T|null         $value
      *
      * @return T
      */
     public static function notNull(mixed $value): mixed
     {
         if ($value === null) {
-            throw new RuntimeException('Expecting value to be not null');
+            throw self::createException('not null', $value);
         }
 
         return $value;
@@ -64,7 +64,7 @@ class Assert
     public static function isArray(mixed $value): array
     {
         if (is_array($value) === false) {
-            throw new RuntimeException('Expecting value to be an array');
+            throw self::createException('an array', $value);
         }
 
         return $value;
@@ -82,7 +82,7 @@ class Assert
     public static function isCallable(mixed $value): callable
     {
         if (is_callable($value) === false) {
-            throw new RuntimeException('Expecting value to be `callable`');
+            throw self::createException('a callable', $value);
         }
 
         return $value;
@@ -100,7 +100,7 @@ class Assert
     public static function resource(mixed $value): mixed
     {
         if (is_resource($value) === false) {
-            throw new RuntimeException('Expecting value to be a `resource`');
+            throw self::createException('a resource', $value);
         }
 
         return $value;
@@ -118,7 +118,7 @@ class Assert
     public static function scalar(mixed $value): mixed
     {
         if (is_scalar($value) === false) {
-            throw new RuntimeException('Expecting value to be a `scalar`');
+            throw self::createException('a scalar', $value);
         }
 
         return $value;
@@ -136,7 +136,7 @@ class Assert
     public static function object(mixed $value): mixed
     {
         if (is_object($value) === false) {
-            throw new RuntimeException('Expecting value to be a `object`');
+            throw self::createException('an object', $value);
         }
 
         return $value;
@@ -154,7 +154,7 @@ class Assert
     public static function integer(mixed $value): int
     {
         if (is_int($value) === false) {
-            throw new RuntimeException('Expecting value to be an int');
+            throw self::createException('an int', $value);
         }
 
         return $value;
@@ -172,7 +172,7 @@ class Assert
     public static function float(mixed $value): float
     {
         if (is_float($value) === false) {
-            throw new RuntimeException('Expecting value to be a float');
+            throw self::createException('a float', $value);
         }
 
         return $value;
@@ -190,7 +190,7 @@ class Assert
     public static function string(mixed $value): string
     {
         if (is_string($value) === false) {
-            throw new RuntimeException('Expecting value to be a string');
+            throw self::createException('a string', $value);
         }
 
         return $value;
@@ -202,6 +202,7 @@ class Assert
      * @phpstan-assert non-empty-string $value
      *
      * @param T                         $value
+     *
      * @return T&non-empty-string
      */
     public static function nonEmptyString(mixed $value): string
@@ -209,7 +210,7 @@ class Assert
         Assert::string($value);
 
         if (strlen($value) === 0) {
-            throw new RuntimeException('Expecting value to be a non empty string');
+            throw self::createException('a non empty string', $value);
         }
 
         return $value;
@@ -227,7 +228,7 @@ class Assert
     public static function boolean(mixed $value): bool
     {
         if (is_bool($value) === false) {
-            throw new RuntimeException('Expecting value to be a boolean');
+            throw self::createException('a boolean', $value);
         }
 
         return $value;
@@ -245,7 +246,7 @@ class Assert
     public static function true(mixed $value): bool
     {
         if ($value !== true) {
-            throw new RuntimeException('Expecting value to be true');
+            throw self::createException('true', $value);
         }
 
         return true;
@@ -263,7 +264,7 @@ class Assert
     public static function false(mixed $value): bool
     {
         if ($value !== false) {
-            throw new RuntimeException('Expecting value to be false');
+            throw self::createException('false', $value);
         }
 
         return false;
@@ -274,14 +275,14 @@ class Assert
      * @template       T
      * @phpstan-assert !false $value
      *
-     * @param T|false $value
+     * @param T|false         $value
      *
      * @return T
      */
     public static function notFalse(mixed $value): mixed
     {
         if ($value === false) {
-            throw new RuntimeException('Expecting value to be not false');
+            throw self::createException('not false', $value);
         }
 
         return $value;
@@ -299,9 +300,14 @@ class Assert
     public static function isInstanceOf(mixed $value, string $classString): object
     {
         if ($value instanceof $classString === false) {
-            throw new RuntimeException('Expecting value to be instance of ' . $classString);
+            throw self::createException('instance of ' . $classString, $value);
         }
 
         return $value;
+    }
+
+    private static function createException(string $expectedType, mixed $value): RuntimeException
+    {
+        return new RuntimeException(sprintf('Expecting value to be %s, `%s` was given', $expectedType, get_debug_type($value)));
     }
 }

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -15,7 +15,7 @@ class AssertTest extends TestCase
     public function testNullFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be null');
+        $this->expectExceptionMessage('Expecting value to be null, `string` was given');
         Assert::null('foobar');
     }
 
@@ -27,7 +27,7 @@ class AssertTest extends TestCase
     public function testNotNullFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be not null');
+        $this->expectExceptionMessage('Expecting value to be not null, `null` was given');
         Assert::notNull(null);
     }
 
@@ -40,7 +40,7 @@ class AssertTest extends TestCase
     public function testIsArrayFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be an array');
+        $this->expectExceptionMessage('Expecting value to be an array, `string` was given');
         Assert::isArray('foobar'); // @phpstan-ignore-line
     }
 
@@ -59,7 +59,7 @@ class AssertTest extends TestCase
     public function testIsCallableFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a callable');
+        $this->expectExceptionMessage('Expecting value to be a callable, `string` was given');
         Assert::isCallable('string');
     }
 
@@ -71,7 +71,7 @@ class AssertTest extends TestCase
     public function testScalarFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a scalar');
+        $this->expectExceptionMessage('Expecting value to be a scalar, `stdClass` was given');
         Assert::scalar(new stdClass()); // @phpstan-ignore-line
     }
 
@@ -83,7 +83,7 @@ class AssertTest extends TestCase
     public function testResourceFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a resource');
+        $this->expectExceptionMessage('Expecting value to be a resource, `string` was given');
         Assert::resource('string'); // @phpstan-ignore-line
     }
 
@@ -96,7 +96,7 @@ class AssertTest extends TestCase
     public function testObjectFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be an object');
+        $this->expectExceptionMessage('Expecting value to be an object, `string` was given');
         Assert::object('string'); // @phpstan-ignore-line
     }
 
@@ -108,7 +108,7 @@ class AssertTest extends TestCase
     public function testIntegerFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be an int');
+        $this->expectExceptionMessage('Expecting value to be an int, `string` was given');
         Assert::integer('string'); // @phpstan-ignore-line
     }
 
@@ -120,14 +120,14 @@ class AssertTest extends TestCase
     public function testFloatFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a float');
+        $this->expectExceptionMessage('Expecting value to be a float, `string` was given');
         Assert::float('string'); // @phpstan-ignore-line
     }
 
     public function testStringFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a string');
+        $this->expectExceptionMessage('Expecting value to be a string, `int` was given');
         Assert::string(123); // @phpstan-ignore-line
     }
 
@@ -139,14 +139,14 @@ class AssertTest extends TestCase
     public function testNonEmptyStringNoStringFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a string');
+        $this->expectExceptionMessage('Expecting value to be a string, `int` was given');
         Assert::nonEmptyString(123); // @phpstan-ignore-line
     }
 
     public function testNonEmptyStringFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a non empty string');
+        $this->expectExceptionMessage('Expecting value to be a non empty string, `string` was given');
         Assert::nonEmptyString('');
     }
 
@@ -164,14 +164,14 @@ class AssertTest extends TestCase
     public function testBooleanFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a boolean');
+        $this->expectExceptionMessage('Expecting value to be a boolean, `string` was given');
         Assert::boolean('string'); // @phpstan-ignore-line
     }
 
     public function testTrueFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be true');
+        $this->expectExceptionMessage('Expecting value to be true, `false` was given');
         Assert::true(false);
     }
 
@@ -183,7 +183,7 @@ class AssertTest extends TestCase
     public function testFalseFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be false');
+        $this->expectExceptionMessage('Expecting value to be false, `true` was given');
         Assert::false(true);
     }
 
@@ -195,7 +195,7 @@ class AssertTest extends TestCase
     public function testNotFalseFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be not false');
+        $this->expectExceptionMessage('Expecting value to be not false, `false` was given');
         Assert::notFalse(false);
     }
 
@@ -209,7 +209,7 @@ class AssertTest extends TestCase
     {
         $object = new stdClass();
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be instance of RuntimeException');
+        $this->expectExceptionMessage('Expecting value to be instance of RuntimeException, `stdClass` was given');
         Assert::isInstanceOf($object, RuntimeException::class); // @phpstan-ignore-line
     }
 

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -59,7 +59,7 @@ class AssertTest extends TestCase
     public function testIsCallableFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be `callable`');
+        $this->expectExceptionMessage('Expecting value to be a callable');
         Assert::isCallable('string');
     }
 
@@ -71,7 +71,7 @@ class AssertTest extends TestCase
     public function testScalarFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a `scalar`');
+        $this->expectExceptionMessage('Expecting value to be a scalar');
         Assert::scalar(new stdClass()); // @phpstan-ignore-line
     }
 
@@ -83,7 +83,7 @@ class AssertTest extends TestCase
     public function testResourceFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a `resource`');
+        $this->expectExceptionMessage('Expecting value to be a resource');
         Assert::resource('string'); // @phpstan-ignore-line
     }
 
@@ -96,7 +96,7 @@ class AssertTest extends TestCase
     public function testObjectFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a `object`');
+        $this->expectExceptionMessage('Expecting value to be an object');
         Assert::object('string'); // @phpstan-ignore-line
     }
 


### PR DESCRIPTION
When throwing an exception, show the type of the incorrect value.