### PR TITLE
Add removeTypes and removeNull to Arrays class

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ A library with everyday use classes and methods:
 - `remove` - Remove an element from an array based on the callback. Supports `EquatableInterface`.
 - `removeKey` - Remove an element from an array based on the key.
 - `removeKeys` - Remove multiple elements from an array based on the keys.
+- `removeTypes` - Filters an array by removing all values that match the provided types.
+- `removeNull` - Filters an array by removing all null values.
 - `search` - Find the key of an element in an array or false otherwise. Supports `EquatableInterface`.
 - `unique` - Remove duplicate values from an array. Supports `EquatableInterface`.
 - `wrap` - Wrap a value in an array, unless it is already an array.
-- `removeTypes` - Filters an array by removing all values that match the provided types.
-- `removeNull` - Filters an array by removing all null values.
 
 ## Assert
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ A library with everyday use classes and methods:
 - `search` - Find the key of an element in an array or false otherwise. Supports `EquatableInterface`.
 - `unique` - Remove duplicate values from an array. Supports `EquatableInterface`.
 - `wrap` - Wrap a value in an array, unless it is already an array.
+- `removeTypes` - Filters an array by removing all values that match the provided types.
+- `removeNull` - Filters an array by removing all null values.
 
 ## Assert
 

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -354,17 +354,19 @@ class Arrays
      */
     public static function removeTypes(array $items, array $disallowedTypes): array
     {
-        return array_filter($items, fn($element) => in_array(get_debug_type($element), $disallowedTypes) === false);
+        return array_filter($items, fn($element) => in_array(get_debug_type($element), $disallowedTypes, true) === false);
     }
 
     /**
      * @template T
      * @param array<T|null> $items
-     * @phpstan-assert array<T>
      * @return array<T>
      */
     public static function removeNull($items): array
     {
-        return self::removeTypes($items, ['null']);
+        /** @var array<T> $result */
+        $result = self::removeTypes($items, ['null']);
+
+        return $result;
     }
 }

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -341,4 +341,30 @@ class Arrays
 
         return [$value];
     }
+
+
+    /**
+     * Filter out elements of specified types from an array.
+     * @template T
+     *
+     * @param T[]      $items
+     * @param string[] $disallowedTypes
+     *
+     * @return T[] The filtered array containing only elements not matching the specified types.
+     */
+    public static function removeTypes(array $items, array $disallowedTypes): array
+    {
+        return array_filter($items, fn($element) => in_array(get_debug_type($element), $disallowedTypes) === false);
+    }
+
+    /**
+     * @template T
+     * @param array<T|null> $items
+     * @phpstan-assert array<T>
+     * @return array<T>
+     */
+    public static function removeNull($items): array
+    {
+        return self::removeTypes($items, ['null']);
+    }
 }

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -346,11 +346,12 @@ class Arrays
     /**
      * Filter out elements of specified types from an array.
      * @template T
+     * @template K
      *
-     * @param T[]      $items
-     * @param string[] $disallowedTypes
+     * @param array<K, T> $items
+     * @param string[]    $disallowedTypes
      *
-     * @return T[] The filtered array containing only elements not matching the specified types.
+     * @return array<K, T> The filtered array containing only elements not matching the specified types.
      */
     public static function removeTypes(array $items, array $disallowedTypes): array
     {

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -359,12 +359,14 @@ class Arrays
 
     /**
      * @template T
-     * @param array<T|null> $items
-     * @return array<T>
+     * @template K
+     * @param array<K, T|null> $items
+     *
+     * @return array<K, T>
      */
     public static function removeNull($items): array
     {
-        /** @var array<T> $result */
+        /** @var array<K, T> $result */
         $result = self::removeTypes($items, ['null']);
 
         return $result;

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -223,6 +223,36 @@ class Arrays
     }
 
     /**
+     * Filter out elements of specified types from an array.
+     * @template T
+     * @template K
+     *
+     * @param array<K, T> $items
+     * @param string[]    $disallowedTypes
+     *
+     * @return array<K, T> The filtered array containing only elements not matching the specified types.
+     */
+    public static function removeTypes(array $items, array $disallowedTypes): array
+    {
+        return array_filter($items, static fn($element) => in_array(get_debug_type($element), $disallowedTypes, true) === false);
+    }
+
+    /**
+     * @template T
+     * @template K
+     * @param array<K, T|null> $items
+     *
+     * @return array<K, T>
+     */
+    public static function removeNull($items): array
+    {
+        /** @var array<K, T> $result */
+        $result = self::removeTypes($items, ['null']);
+
+        return $result;
+    }
+
+    /**
      * Strict test if `value` is contained within `items`. Method supports `EquatableInterface`.
      *
      * @param array<mixed|EquatableInterface> $items
@@ -340,36 +370,5 @@ class Arrays
         }
 
         return [$value];
-    }
-
-
-    /**
-     * Filter out elements of specified types from an array.
-     * @template T
-     * @template K
-     *
-     * @param array<K, T> $items
-     * @param string[]    $disallowedTypes
-     *
-     * @return array<K, T> The filtered array containing only elements not matching the specified types.
-     */
-    public static function removeTypes(array $items, array $disallowedTypes): array
-    {
-        return array_filter($items, static fn($element) => in_array(get_debug_type($element), $disallowedTypes, true) === false);
-    }
-
-    /**
-     * @template T
-     * @template K
-     * @param array<K, T|null> $items
-     *
-     * @return array<K, T>
-     */
-    public static function removeNull($items): array
-    {
-        /** @var array<K, T> $result */
-        $result = self::removeTypes($items, ['null']);
-
-        return $result;
     }
 }

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -355,7 +355,7 @@ class Arrays
      */
     public static function removeTypes(array $items, array $disallowedTypes): array
     {
-        return array_filter($items, fn($element) => in_array(get_debug_type($element), $disallowedTypes, true) === false);
+        return array_filter($items, static fn($element) => in_array(get_debug_type($element), $disallowedTypes, true) === false);
     }
 
     /**

--- a/tests/Unit/ArraysTest.php
+++ b/tests/Unit/ArraysTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace DR\Utils\Tests\Unit;
 
 use DR\Utils\Arrays;
+use DR\Utils\Assert;
 use DR\Utils\Tests\Mock\MockComparable;
 use DR\Utils\Tests\Mock\MockEquatable;
 use InvalidArgumentException;
@@ -230,5 +231,23 @@ class ArraysTest extends TestCase
         static::assertSame([], Arrays::wrap(null, false));
         static::assertSame(['foobar'], Arrays::wrap('foobar'));
         static::assertSame(['foobar'], Arrays::wrap(['foobar']));
+    }
+
+    public function testRemoveTypes(): void
+    {
+        $input = [false, 0, '0', 'false', true, 1, '1', 'true'];
+        static::assertEqualsCanonicalizing([0, '0', 'false', 1, '1', 'true'], Arrays::removeTypes($input, ['bool']));
+        static::assertSame(['null'], Arrays::removeTypes(['null', null], ['null']));
+        static::assertSame(['1', 2.00], Arrays::removeTypes(['1', 2.00, 3], ['int']));
+        static::assertSame([1, '2.00'], Arrays::removeTypes([1, '2.00', 3.00], ['float']));
+        static::assertSame([], Arrays::removeTypes(['UT string'], ['string']));
+        static::assertSame([], Arrays::removeTypes([[1, 2, 3]], ['array']));
+        static::assertSame([], Arrays::removeTypes([new stdClass()], ['stdClass']));
+        static::assertSame([], Arrays::removeTypes([new Arrays()], [Arrays::class]));
+    }
+
+    public function testRemoveNull(): void
+    {
+        static::assertSame(['null'], Arrays::removeNull(['null', null]));
     }
 }


### PR DESCRIPTION
This PR introduces two PHP functions for array filtering:

removeTypes function:
- Filters out elements of specified types from an array
- Inputs: 
   - An mixed array $items 
   - An array of strings with disallowed types (supported: bool, null, int, float, string, array, stdClass, class)
- Outputs a new array with elements not matching the disallowed types.

removeNull function:

- Wrapper function internally using removeTypes
- Removes null values from an array.
- Takes an array with potentially null values as input.
- Produces a new array without any null values.