### PR TITLE
Improve int float string types in error message

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace DR\Utils;
 
-use RuntimeException;
+use DR\Utils\Exception\ExceptionFactory;
 
 use function is_bool;
 use function is_callable;
@@ -28,7 +28,7 @@ class Assert
     public static function null(mixed $value): mixed
     {
         if ($value !== null) {
-            throw self::createException('null', $value);
+            throw ExceptionFactory::createException('null', $value);
         }
 
         return null;
@@ -46,7 +46,7 @@ class Assert
     public static function notNull(mixed $value): mixed
     {
         if ($value === null) {
-            throw self::createException('not null', $value);
+            throw ExceptionFactory::createException('not null', $value);
         }
 
         return $value;
@@ -64,7 +64,7 @@ class Assert
     public static function isArray(mixed $value): array
     {
         if (is_array($value) === false) {
-            throw self::createException('an array', $value);
+            throw ExceptionFactory::createException('an array', $value);
         }
 
         return $value;
@@ -82,7 +82,7 @@ class Assert
     public static function isCallable(mixed $value): callable
     {
         if (is_callable($value) === false) {
-            throw self::createException('a callable', $value);
+            throw ExceptionFactory::createException('a callable', $value);
         }
 
         return $value;
@@ -100,7 +100,7 @@ class Assert
     public static function resource(mixed $value): mixed
     {
         if (is_resource($value) === false) {
-            throw self::createException('a resource', $value);
+            throw ExceptionFactory::createException('a resource', $value);
         }
 
         return $value;
@@ -118,7 +118,7 @@ class Assert
     public static function scalar(mixed $value): mixed
     {
         if (is_scalar($value) === false) {
-            throw self::createException('a scalar', $value);
+            throw ExceptionFactory::createException('a scalar', $value);
         }
 
         return $value;
@@ -136,7 +136,7 @@ class Assert
     public static function object(mixed $value): mixed
     {
         if (is_object($value) === false) {
-            throw self::createException('an object', $value);
+            throw ExceptionFactory::createException('an object', $value);
         }
 
         return $value;
@@ -154,7 +154,7 @@ class Assert
     public static function integer(mixed $value): int
     {
         if (is_int($value) === false) {
-            throw self::createException('an int', $value);
+            throw ExceptionFactory::createException('an int', $value);
         }
 
         return $value;
@@ -172,7 +172,7 @@ class Assert
     public static function float(mixed $value): float
     {
         if (is_float($value) === false) {
-            throw self::createException('a float', $value);
+            throw ExceptionFactory::createException('a float', $value);
         }
 
         return $value;
@@ -190,7 +190,7 @@ class Assert
     public static function string(mixed $value): string
     {
         if (is_string($value) === false) {
-            throw self::createException('a string', $value);
+            throw ExceptionFactory::createException('a string', $value);
         }
 
         return $value;
@@ -210,7 +210,7 @@ class Assert
         Assert::string($value);
 
         if (strlen($value) === 0) {
-            throw self::createException('a non empty string', $value);
+            throw ExceptionFactory::createException('a non empty string', $value);
         }
 
         return $value;
@@ -228,7 +228,7 @@ class Assert
     public static function boolean(mixed $value): bool
     {
         if (is_bool($value) === false) {
-            throw self::createException('a boolean', $value);
+            throw ExceptionFactory::createException('a boolean', $value);
         }
 
         return $value;
@@ -246,7 +246,7 @@ class Assert
     public static function true(mixed $value): bool
     {
         if ($value !== true) {
-            throw self::createException('true', $value);
+            throw ExceptionFactory::createException('true', $value);
         }
 
         return true;
@@ -264,7 +264,7 @@ class Assert
     public static function false(mixed $value): bool
     {
         if ($value !== false) {
-            throw self::createException('false', $value);
+            throw ExceptionFactory::createException('false', $value);
         }
 
         return false;
@@ -282,7 +282,7 @@ class Assert
     public static function notFalse(mixed $value): mixed
     {
         if ($value === false) {
-            throw self::createException('not false', $value);
+            throw ExceptionFactory::createException('not false', $value);
         }
 
         return $value;
@@ -300,7 +300,7 @@ class Assert
     public static function isInstanceOf(mixed $value, string $classString): object
     {
         if ($value instanceof $classString === false) {
-            throw self::createException('instance of ' . $classString, $value);
+            throw ExceptionFactory::createException('instance of ' . $classString, $value);
         }
 
         return $value;
@@ -320,16 +320,9 @@ class Assert
     public static function inArray(mixed $value, array $haystack): mixed
     {
         if (in_array($value, $haystack, true) === false) {
-            throw self::createException('in array $values', $value);
+            throw ExceptionFactory::createException('in array $values', $value);
         }
 
         return $value;
-    }
-
-    private static function createException(string $expectedType, mixed $value): RuntimeException
-    {
-        $type = is_bool($value) ? ($value ? 'true' : 'false') : get_debug_type($value);
-
-        return new RuntimeException(sprintf('Expecting value to be %s, `%s` was given', $expectedType, $type));
     }
 }

--- a/src/Exception/ExceptionFactory.php
+++ b/src/Exception/ExceptionFactory.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Utils\Exception;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+class ExceptionFactory
+{
+    public static function createException(string $expectedType, mixed $value): RuntimeException
+    {
+        if (is_bool($value)) {
+            $type = ($value ? 'true' : 'false') . ' (bool)';
+        } elseif (is_int($value)) {
+            $type = $value . ' (int)';
+        } elseif (is_float($value)) {
+            $type = round($value, 2) . ' (float)';
+        } elseif (is_string($value)) {
+            $type = strlen($value) === 0 ? 'empty-string' : $value . ' (string)';
+        } elseif (is_array($value) && count($value) === 0) {
+            $type = 'empty-array';
+        } else {
+            $type = get_debug_type($value);
+        }
+
+        return new RuntimeException(sprintf('Expecting value to be %s, `%s` was given', $expectedType, $type));
+    }
+}

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -15,7 +15,7 @@ class AssertTest extends TestCase
     public function testNullFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be null, `string` was given');
+        $this->expectExceptionMessage('Expecting value to be null, `foobar (string)` was given');
         Assert::null('foobar');
     }
 
@@ -40,7 +40,7 @@ class AssertTest extends TestCase
     public function testIsArrayFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be an array, `string` was given');
+        $this->expectExceptionMessage('Expecting value to be an array, `foobar (string)` was given');
         Assert::isArray('foobar'); // @phpstan-ignore-line
     }
 
@@ -59,7 +59,7 @@ class AssertTest extends TestCase
     public function testIsCallableFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a callable, `string` was given');
+        $this->expectExceptionMessage('Expecting value to be a callable, `string (string)` was given');
         Assert::isCallable('string');
     }
 
@@ -83,7 +83,7 @@ class AssertTest extends TestCase
     public function testResourceFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a resource, `string` was given');
+        $this->expectExceptionMessage('Expecting value to be a resource, `string (string)` was given');
         Assert::resource('string'); // @phpstan-ignore-line
     }
 
@@ -96,7 +96,7 @@ class AssertTest extends TestCase
     public function testObjectFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be an object, `string` was given');
+        $this->expectExceptionMessage('Expecting value to be an object, `string (string)` was given');
         Assert::object('string'); // @phpstan-ignore-line
     }
 
@@ -108,7 +108,7 @@ class AssertTest extends TestCase
     public function testIntegerFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be an int, `string` was given');
+        $this->expectExceptionMessage('Expecting value to be an int, `string (string)` was given');
         Assert::integer('string'); // @phpstan-ignore-line
     }
 
@@ -120,14 +120,14 @@ class AssertTest extends TestCase
     public function testFloatFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a float, `string` was given');
+        $this->expectExceptionMessage('Expecting value to be a float, `string (string)` was given');
         Assert::float('string'); // @phpstan-ignore-line
     }
 
     public function testStringFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a string, `int` was given');
+        $this->expectExceptionMessage('Expecting value to be a string, `123 (int)` was given');
         Assert::string(123); // @phpstan-ignore-line
     }
 
@@ -139,14 +139,14 @@ class AssertTest extends TestCase
     public function testNonEmptyStringNoStringFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a string, `int` was given');
+        $this->expectExceptionMessage('Expecting value to be a string, `123 (int)` was given');
         Assert::nonEmptyString(123); // @phpstan-ignore-line
     }
 
     public function testNonEmptyStringFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a non empty string, `string` was given');
+        $this->expectExceptionMessage('Expecting value to be a non empty string, `empty-string` was given');
         Assert::nonEmptyString('');
     }
 
@@ -164,14 +164,14 @@ class AssertTest extends TestCase
     public function testBooleanFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be a boolean, `string` was given');
+        $this->expectExceptionMessage('Expecting value to be a boolean, `string (string)` was given');
         Assert::boolean('string'); // @phpstan-ignore-line
     }
 
     public function testTrueFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be true, `false` was given');
+        $this->expectExceptionMessage('Expecting value to be true, `false (bool)` was given');
         Assert::true(false);
     }
 
@@ -183,7 +183,7 @@ class AssertTest extends TestCase
     public function testFalseFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be false, `true` was given');
+        $this->expectExceptionMessage('Expecting value to be false, `true (bool)` was given');
         Assert::false(true);
     }
 
@@ -195,7 +195,7 @@ class AssertTest extends TestCase
     public function testNotFalseFailure(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be not false, `false` was given');
+        $this->expectExceptionMessage('Expecting value to be not false, `false (bool)` was given');
         Assert::notFalse(false);
     }
 
@@ -225,7 +225,7 @@ class AssertTest extends TestCase
         $haystack = [1, '5', false];
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expecting value to be in array $values, `int` was given');
+        $this->expectExceptionMessage('Expecting value to be in array $values, `5 (int)` was given');
         Assert::inArray($value, $haystack);
     }
 

--- a/tests/Unit/Exception/ExceptionFactoryTest.php
+++ b/tests/Unit/Exception/ExceptionFactoryTest.php
@@ -13,7 +13,6 @@ use stdClass;
 #[CoversClass(ExceptionFactory::class)]
 class ExceptionFactoryTest extends TestCase
 {
-
     #[DataProvider('dataProvider')]
     public function testCreateException(mixed $value, string $expectedMessage): void
     {

--- a/tests/Unit/Exception/ExceptionFactoryTest.php
+++ b/tests/Unit/Exception/ExceptionFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Utils\Tests\Unit\Exception;
+
+use DR\Utils\Exception\ExceptionFactory;
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+#[CoversClass(ExceptionFactory::class)]
+class ExceptionFactoryTest extends TestCase
+{
+
+    #[DataProvider('dataProvider')]
+    public function testCreateException(mixed $value, string $expectedMessage): void
+    {
+        $exception = ExceptionFactory::createException('type', $value);
+        static::assertSame($expectedMessage, $exception->getMessage());
+    }
+
+    /**
+     * @return Generator<string, array<int, mixed>>
+     */
+    public static function dataProvider(): Generator
+    {
+        yield 'bool' => [true, 'Expecting value to be type, `true (bool)` was given'];
+        yield 'int' => [1, 'Expecting value to be type, `1 (int)` was given'];
+        yield 'float' => [1.1234, 'Expecting value to be type, `1.12 (float)` was given'];
+        yield 'string' => ['foo', 'Expecting value to be type, `foo (string)` was given'];
+        yield 'empty-string' => ['', 'Expecting value to be type, `empty-string` was given'];
+        yield 'empty-array' => [[], 'Expecting value to be type, `empty-array` was given'];
+        yield 'object' => [new stdClass(), 'Expecting value to be type, `stdClass` was given'];
+        yield 'null' => [null, 'Expecting value to be type, `null` was given'];
+    }
+}


### PR DESCRIPTION
Improve exception message. If value is bool, int, float, string, include the value in the exception message.