### PR TITLE
Add Array::groupBy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -60,4 +60,5 @@
 /php*.json export-ignore
 /php*.xml export-ignore
 /php*.neon export-ignore
+/php*.dist export-ignore
 /renovate.json export-ignore

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A library with everyday use classes and methods:
 - `explode` - Explode a string or null into an array, with exploding empty string to empty array.
 - `mapAssoc` - Map an array to a new array using a callback, preserving keys. 
 - `reindex` - Reindex an array with new keys based on the result of the callback.
+- `groupBy` - Group items by the given return value of the callback.
 - `remove` - Remove an element from an array based on the callback. Supports `EquatableInterface`.
 - `removeKey` - Remove an element from an array based on the key.
 - `removeKeys` - Remove multiple elements from an array based on the keys.

--- a/phpmd.baseline.xml
+++ b/phpmd.baseline.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <phpmd-baseline>
+  <violation rule="PHPMD\Rule\Design\WeightedMethodCount" file="src/Arrays.php"/>
   <violation rule="PHPMD\Rule\Design\TooManyPublicMethods" file="src/Arrays.php"/>
   <violation rule="PHPMD\Rule\Design\WeightedMethodCount" file="src/Assert.php"/>
   <violation rule="PHPMD\Rule\Design\TooManyMethods" file="src/Assert.php"/>

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -177,6 +177,32 @@ class Arrays
     }
 
     /**
+     * Group items by the given return value of the callback.
+     * <code>
+     *     $data   = [1, 2, 3, 4];
+     *     $values = Arrays::groupBy($data, fn($val) => $val % 2);
+     *     // output: [0 => [2, 4], 1 => [1, 3]]
+     * </code>
+     * @template TKey of int|string
+     * @template TValue
+     * @template K of int|string
+     *
+     * @param iterable<TKey, TValue>      $items
+     * @param (callable(TValue, TKey): K) $callback
+     *
+     * @return array<K, array<TKey, TValue>>
+     */
+    public static function groupBy(iterable $items, callable $callback): array
+    {
+        $result = [];
+        foreach ($items as $key => $value) {
+            $result[$callback($value, $key)][$key] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
      * Remove an item from the given array. This method supports the EquatableInterface to
      * determine if 2 different objects are equal.
      * @template T of mixed|EquatableInterface

--- a/tests/Unit/ArraysTest.php
+++ b/tests/Unit/ArraysTest.php
@@ -79,6 +79,23 @@ class ArraysTest extends TestCase
         static::assertSame([3 => 'foo', 6 => 'foobar'], Arrays::reindex(new ArrayIterator(['foo', 'foobar']), $callback));
     }
 
+    public function testGroupBy(): void
+    {
+        $data     = ['aaa' => 1, 'bbb' => 2, 'ccc' => 3, 'ddd' => 4];
+        $callback = static fn($value) => $value % 2 === 0 ? 'even' : 'odd';
+        $expected = [
+            'odd'  => [
+                'aaa' => 1,
+                'ccc' => 3,
+            ],
+            'even' => [
+                'bbb' => 2,
+                'ddd' => 4,
+            ],
+        ];
+        static::assertSame($expected, Arrays::groupBy($data, $callback));
+    }
+
     public function testFind(): void
     {
         $objA  = new stdClass();


### PR DESCRIPTION
Adds `Arrays::groupBy($items, $callback)` to group values of an array by the value returned by the callback.