### PR TITLE
Add Assert::classString

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Fluent assertion methods, inspired by `webmozart/assert`:
 - `numeric`
 - `float`
 - `string`
+- `classString`
 - `startsWith`
 - `notStartsWith`
 - `endsWith`

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -245,7 +245,7 @@ class Assert
      * Assert value is a class-string
      * @template       T
      *
-     * @phpstan-assert string $value
+     * @phpstan-assert class-string $value
      *
      * @param T               $value
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -242,6 +242,27 @@ class Assert
     }
 
     /**
+     * Assert value is a class-string
+     * @template       T
+     *
+     * @phpstan-assert string $value
+     *
+     * @param T               $value
+     *
+     * @return T&class-string
+     */
+    public static function classString(mixed $value, ?string $message = null): string
+    {
+        self::string($value, $message);
+
+        if (class_exists($value) === false) {
+            throw ExceptionFactory::createException('a class-string but class does not exist', $value, $message);
+        }
+
+        return $value;
+    }
+
+    /**
      * Assert string starts with the given prefix
      * @template T of string|Stringable
      *

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -173,6 +173,27 @@ class AssertTest extends TestCase
         static::assertSame($stringable, Assert::stringable($stringable));
     }
 
+    #[TestWith([Assert::class])]
+    #[TestWith(['DR\Utils\Assert'])]
+    public function testClassString(string $value): void
+    {
+        static::assertSame($value, Assert::classString($value));
+    }
+
+    public function testClassStringStringFailure(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Expecting value to be a string, `123 (int)` was given');
+        Assert::classString(123);
+    }
+
+    public function testClassStringClassFailure(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Expecting value to be a class-string but class does not exist, `DR\Utils\FakeClass (string)` was given');
+        Assert::classString('DR\Utils\FakeClass');
+    }
+
     #[TestWith(['string', 'str', true])]
     #[TestWith(['string', 'str', false])]
     #[TestWith(['string', 'STR', false])]

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -184,7 +184,7 @@ class AssertTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expecting value to be a string, `123 (int)` was given');
-        Assert::classString(123);
+        Assert::classString(123); // @phpstan-ignore-line
     }
 
     public function testClassStringClassFailure(): void


### PR DESCRIPTION
New assertion added to assert that a ::class or a fully qualified namespace as a string is a class-string type