### PR TITLE
Refactor typeSpecifier call to use named argument for scope

### DIFF
--- a/src/PHPStan/Extension/AssertTypeTypeSpecifyingExtension.php
+++ b/src/PHPStan/Extension/AssertTypeTypeSpecifyingExtension.php
@@ -66,6 +66,6 @@ class AssertTypeTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExt
         [$item, $allowedTypes] = $node->getArgs();
         $type = $this->typeNarrower->narrow($item, $allowedTypes, $scope);
 
-        return $this->typeSpecifier->create($item->value, $type, TypeSpecifierContext::createTruthy(), $scope);
+        return $this->typeSpecifier->create($item->value, $type, TypeSpecifierContext::createTruthy(), scope: $scope);
     }
 }


### PR DESCRIPTION
fixes "Internal error: PHPStan\Analyser\TypeSpecifier::create(): Argument #4 ($overwrite) must be of type bool, PHPStan\Analyser\MutatingScope given"