### PR TITLE
Improve performance of Arrays::removeNull method

### DIFF
--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -347,7 +347,7 @@ class Arrays
      */
     public static function removeNull(array $items): array
     {
-        return self::removeTypes($items, ['null']);
+        return array_filter($items, static fn($element) => $element !== null);
     }
 
     /**


### PR DESCRIPTION
Was unnecessary complex and can have for its usage a very simple implementation