### PR TITLE
Add Arrays::mapKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ A library with everyday use classes and methods:
 - `equals` - Tests if two arrays have equal contents, ignoring order. Supports `ComparableInterface`.
 - `explode` - Explode a string or null into an array, with exploding empty string to empty array.
 - `map` - Similar to `array_map` but with support for `iterable`, and receive key as second argument in the callback.
-- `mapAssoc` - Map an array to a new array using a callback, preserving keys. 
+- `mapAssoc` - Map an array to a new array using a callback, preserving keys.
+- `mapKey` - Map an array to a new keyed array using a callback,
 - `reindex` - Reindex an array with new keys based on the result of the callback.
 - `groupBy` - Group items by the given return value of the callback.
 - `renameKey` - Rename the `string` key of an array element.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A library with everyday use classes and methods:
 - `explode` - Explode a string or null into an array, with exploding empty string to empty array.
 - `map` - Similar to `array_map` but with support for `iterable`, and receive key as second argument in the callback.
 - `mapAssoc` - Map an array to a new array using a callback, preserving keys.
-- `mapKey` - Map an array to a new keyed array using a callback,
+- `mapKeys` - Map an array to a new keyed array using a callback,
 - `reindex` - Reindex an array with new keys based on the result of the callback.
 - `groupBy` - Group items by the given return value of the callback.
 - `renameKey` - Rename the `string` key of an array element.

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -154,7 +154,7 @@ class Arrays
      * Example:
      * <code>
      *    $data = ['FOO' => true, 'BAR' => false];
-     *    $data = Arrays::mapKey($data, static fn(string $key): string => strtolower($key));
+     *    $data = Arrays::mapKeys($data, static fn(string $key): string => strtolower($key));
      *    // output: ['foo' => true, 'bar' => false]
      * </code>
      * @template T

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -149,6 +149,34 @@ class Arrays
     }
 
     /**
+     * Similar to <code>array_map</code> but instead of converting the value of the array, the key will be converted. The original value of the
+     * key will be assigned to the new key. The callback receives the key as the first argument and the value as the second argument.
+     * Example:
+     * <code>
+     *    $data = ['FOO' => true, 'BAR' => false];
+     *    $data = Arrays::mapKey($data, static fn(string $key): string => strtolower($key));
+     *    // output: ['foo' => true, 'bar' => false]
+     * </code>
+     * @template T
+     * @template K1 of array-key
+     * @template K2 of array-key
+     *
+     * @param iterable<K1, T>       $items
+     * @param (callable(K1): K2) $callback
+     *
+     * @return array<K2, T>
+     */
+    public static function mapKey(iterable $items, callable $callback): array
+    {
+        $result = [];
+        foreach ($items as $key => $value) {
+            $result[$callback($key)] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
      * Map an array to key-value pair by the given return values of the callback.
      * <code>
      *      $data = [1, 2, 3];

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -150,7 +150,7 @@ class Arrays
 
     /**
      * Similar to <code>array_map</code> but instead of converting the value of the array, the key will be converted. The original value of the
-     * key will be assigned to the new key. The callback receives the key as the first argument and the value as the second argument.
+     * key will be assigned to the new key.
      * Example:
      * <code>
      *    $data = ['FOO' => true, 'BAR' => false];
@@ -166,7 +166,7 @@ class Arrays
      *
      * @return array<K2, T>
      */
-    public static function mapKey(iterable $items, callable $callback): array
+    public static function mapKeys(iterable $items, callable $callback): array
     {
         $result = [];
         foreach ($items as $key => $value) {

--- a/tests/Unit/ArraysTest.php
+++ b/tests/Unit/ArraysTest.php
@@ -78,6 +78,14 @@ class ArraysTest extends TestCase
         static::assertSame([2 => false, 4 => true, 6 => false], Arrays::mapAssoc([1, 2, 3], static fn(int $val) => [$val * 2, $val % 2 === 0]));
     }
 
+    public function testMapKeys(): void
+    {
+        $callback = static fn(string $key): string => strtolower($key);
+        static::assertSame([], Arrays::mapKeys([], $callback));
+        static::assertSame(['foo' => 'bar'], Arrays::mapKeys(['FOO' => 'bar'], $callback));
+        static::assertSame(['foo' => 'bar', 'bar' => 123], Arrays::mapKeys(new ArrayIterator(['FOO' => 'bar', 'BAR' => 123]), $callback));
+    }
+
     public function testReindex(): void
     {
         $callback = static fn(string $value) => strlen($value);
@@ -348,7 +356,7 @@ class ArraysTest extends TestCase
 
     public function testFromJson(): void
     {
-        $jsonString = '{"key": "value", "number": 123}';
+        $jsonString    = '{"key": "value", "number": 123}';
         $expectedArray = ["key" => "value", "number" => 123];
 
         $result = Arrays::fromJson($jsonString);


### PR DESCRIPTION
Adds `Arrays::mapKeys` which transforms the keys of an array to a new key

Example
```php
$data = ['FOO' => true, 'BAR' => false];
$data = Arrays::mapKeys($data, static fn(string $key): string => strtolower($key));
// output: ['foo' => true, 'bar' => false]
```