### PR TITLE
Add Assert::emptyArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Fluent assertion methods, inspired by `webmozart/assert`:
 - `true`
 - `false`
 - `notFalse`
+- `emptyArray`
 - `nonEmptyArray`
 - `nonEmptyString`
 - `isInstanceOf`

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -468,6 +468,25 @@ class Assert
     }
 
     /**
+     * Assert value is an empty array
+     * @template       T
+     * @phpstan-assert array{} $value
+     *
+     * @param T                $value
+     *
+     * @return array{}
+     */
+    public static function emptyArray(mixed $value, ?string $message = null): array
+    {
+        $array = static::isArray($value, $message);
+        if (count($array) !== 0) {
+            throw new RuntimeException(sprintf('Expecting array to be empty%s', $message === null ? '' : '. ' . $message));
+        }
+
+        return $array;
+    }
+
+    /**
      * Assert value is a non-empty array
      * @template       T
      * @phpstan-assert non-empty-array<array-key, mixed> $value

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -280,7 +280,7 @@ class AssertTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expecting array to be empty. More context about failure.');
-        Assert::emptyArray(['foo'], 'More context about failure.'); // @phpstan-ignore-line
+        Assert::emptyArray(['foo'], 'More context about failure.');
     }
 
     public function testEmptyArray(): void

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -276,11 +276,18 @@ class AssertTest extends TestCase
         Assert::notEndsWith($value, $suffix, $caseSensitive, 'More context about failure.');
     }
 
-    public function testEmptyArrayFailure(): void
+    public function testEmptyArrayFailureWithFilledArray(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expecting array to be empty. More context about failure.');
         Assert::emptyArray(['foo'], 'More context about failure.');
+    }
+
+    public function testEmptyArrayFailureWithNonArray(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Expecting value to be an array');
+        Assert::emptyArray('string', 'More context about failure.');
     }
 
     public function testEmptyArray(): void

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -276,6 +276,18 @@ class AssertTest extends TestCase
         Assert::notEndsWith($value, $suffix, $caseSensitive, 'More context about failure.');
     }
 
+    public function testEmptyArrayFailure(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Expecting array to be empty. More context about failure.');
+        Assert::emptyArray(['foo'], 'More context about failure.'); // @phpstan-ignore-line
+    }
+
+    public function testEmptyArray(): void
+    {
+        static::assertSame([], Assert::emptyArray([]));
+    }
+
     public function testNonEmptyArrayFailure(): void
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
Adds `Assert::emptyArray` which asserts an value should be of type `array` and be `[]`