### PR TITLE
Add Closures::unfold function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ stdClass => 'stdClass'
 resource => 'resource (stream)'
 ``` 
 
+## Closures
+
+- `unfold`
+
+Turns a variable with a closure into the return type of that closure.  
+Can be called multiple times on the same variable, but will only execute the closure once.  
+```php
+    $service = fn() => new Service();
+    Closures::unfold($service);
+    $service instanceof Service // true
+```
+
 ## Installation
 
 ```shell

--- a/src/Closures.php
+++ b/src/Closures.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Utils;
+
+use Closure;
+
+class Closures
+{
+    /**
+     * @template T of object
+     * @phpstan-param T|Closure(): T $closure
+     * @param-out T $closure
+     *
+     * @phpstan-return T
+     */
+    public static function unfold(object &$closure): object
+    {
+        if ($closure instanceof Closure) {
+            /** @phpstan-var T $object */
+            $object = ($closure)();
+            $closure = $object;
+        }
+
+        /** @phpstan-var T $closure */
+        return $closure;
+    }
+}

--- a/src/Closures.php
+++ b/src/Closures.php
@@ -11,19 +11,19 @@ class Closures
     /**
      * Calls the Closure and assigns its return value to the variable passed in to this function
      *
-     * @template T of object
+     * @template T
      * @param T $closure Is overwritten by its return value
      * @phpstan-param T|Closure(): T $closure
      * @param-out T $closure
      *
      * @phpstan-return T
      */
-    public static function unfold(object &$closure): object
+    public static function unfold(mixed &$closure): mixed
     {
         if ($closure instanceof Closure) {
-            /** @phpstan-var T $object */
-            $object = ($closure)();
-            $closure = $object;
+            /** @phpstan-var T $value */
+            $value = ($closure)();
+            $closure = $value;
         }
 
         /** @phpstan-var T $closure */

--- a/src/Closures.php
+++ b/src/Closures.php
@@ -9,6 +9,8 @@ use Closure;
 class Closures
 {
     /**
+     * Calls the Closure and assigns its return value to the variable passed in to this function
+     *
      * @template T of object
      * @phpstan-param T|Closure(): T $closure
      * @param-out T $closure

--- a/src/Closures.php
+++ b/src/Closures.php
@@ -12,6 +12,7 @@ class Closures
      * Calls the Closure and assigns its return value to the variable passed in to this function
      *
      * @template T of object
+     * @param T $closure Is overwritten by its return value
      * @phpstan-param T|Closure(): T $closure
      * @param-out T $closure
      *

--- a/tests/Unit/ClosuresTest.php
+++ b/tests/Unit/ClosuresTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Utils\Tests\Unit;
+
+use DR\Utils\Closures;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+#[CoversClass(Closures::class)]
+class ClosuresTest extends TestCase
+{
+    public function testUnfold(): void
+    {
+        $class = new stdClass();
+        $closure = static fn() => $class;
+
+        $unfolded = Closures::unfold($closure);
+        static::assertSame($class, $unfolded);
+        static::assertSame($unfolded, Closures::unfold($closure));
+    }
+}

--- a/tests/Unit/ClosuresTest.php
+++ b/tests/Unit/ClosuresTest.php
@@ -7,26 +7,21 @@ namespace DR\Utils\Tests\Unit;
 use DR\Utils\Closures;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 #[CoversClass(Closures::class)]
 class ClosuresTest extends TestCase
 {
     public function testUnfold(): void
     {
-        $class = new class() {
-            public int $counter = 0;
-
-            public function __construct()
-            {
-                $this->counter++;
-            }
+        $counter = 0;
+        $closure = static function () use (&$counter): stdClass {
+            $counter++;
+            return new stdClass();
         };
-        $closure = static fn() => $class;
-
-        $unfolded = Closures::unfold($closure);
-        static::assertSame($class, $unfolded);
-        static::assertSame(1, $class->counter);
-        static::assertSame($unfolded, Closures::unfold($closure));
-        static::assertSame(1, $class->counter);
+        $unfolded1 = Closures::unfold($closure);
+        $unfolded2 = Closures::unfold($closure);
+        static::assertSame($unfolded1, $unfolded2);
+        static::assertSame(1, $counter);
     }
 }

--- a/tests/Unit/ClosuresTest.php
+++ b/tests/Unit/ClosuresTest.php
@@ -7,18 +7,26 @@ namespace DR\Utils\Tests\Unit;
 use DR\Utils\Closures;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 #[CoversClass(Closures::class)]
 class ClosuresTest extends TestCase
 {
     public function testUnfold(): void
     {
-        $class = new stdClass();
+        $class = new class() {
+            public int $counter = 0;
+
+            public function __construct()
+            {
+                $this->counter++;
+            }
+        };
         $closure = static fn() => $class;
 
         $unfolded = Closures::unfold($closure);
         static::assertSame($class, $unfolded);
+        static::assertSame(1, $class->counter);
         static::assertSame($unfolded, Closures::unfold($closure));
+        static::assertSame(1, $class->counter);
     }
 }


### PR DESCRIPTION
Utility function to replace the repeated pattern of 
```
  if ($this->service instanceof Closure) {
      $this->service = ($this->service )();
  }

  return $this->service ; 
```
That is often used to make lazy loaded services