### PR TITLE
Adds Arrays::implode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A library with everyday use classes and methods:
 - `find` - Find the first element in an array that matches a predicate, exception otherwise.
 - `findOrNull` - Find the first element in an array that matches a predicate, null otherwise.
 - `flatten` - Recursively flattens an array returning an array with all the elements.
-- `implode` - Implode an array into a string. Supports array of boolean, int, float, string, null, Stringable and BackedEnum. 
+- `implode` - Implode an iterable into a string. Supports iterable of boolean, int, float, string, null, Stringable and BackedEnum.
 - `contains` - Test if the given value is contained within items. Supports `EquatableInterface`.
 - `diff` - Get the difference between two arrays. Supports `ComparableInterface`.
 - `equals` - Tests if two arrays have equal contents, ignoring order. Supports `ComparableInterface`.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A library with everyday use classes and methods:
 - `find` - Find the first element in an array that matches a predicate, exception otherwise.
 - `findOrNull` - Find the first element in an array that matches a predicate, null otherwise.
 - `flatten` - Recursively flattens an array returning an array with all the elements.
+- `implode` - Implode an array into a string. Supports array of boolean, int, float, string, null, Stringable and BackedEnum. 
 - `contains` - Test if the given value is contained within items. Supports `EquatableInterface`.
 - `diff` - Get the difference between two arrays. Supports `ComparableInterface`.
 - `equals` - Tests if two arrays have equal contents, ignoring order. Supports `ComparableInterface`.

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -649,6 +649,7 @@ class Arrays
         }
         $current = $value;
 
+        /** @phpstan-var mixed[] */
         return $array;
     }
 }

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -570,6 +570,9 @@ class Arrays
      */
     public static function implode(iterable $items, string $separator = ','): string
     {
+        if ($separator === '') {
+            throw new InvalidArgumentException('Separator cannot be empty');
+        }
         $result = [];
         foreach ($items as $item) {
             if ($item instanceof BackedEnum) {

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -565,8 +565,8 @@ class Arrays
     }
 
     /**
-     * @param array<null|bool|int|string|float|Stringable|BackedEnum> $items
-     * @param non-empty-string                                        $separator
+     * @param iterable<null|bool|int|string|float|Stringable|BackedEnum> $items
+     * @param non-empty-string                                            $separator
      */
     public static function implode(iterable $items, string $separator = ','): string
     {

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace DR\Utils;
 
+use BackedEnum;
 use InvalidArgumentException;
 use JsonException;
 use RuntimeException;
+use Stringable;
 
 use function array_diff_key;
 use function array_filter;
@@ -161,7 +163,7 @@ class Arrays
      * @template K1 of array-key
      * @template K2 of array-key
      *
-     * @param iterable<K1, T>       $items
+     * @param iterable<K1, T>    $items
      * @param (callable(K1): K2) $callback
      *
      * @return array<K2, T>
@@ -560,6 +562,24 @@ class Arrays
         );
 
         return $result;
+    }
+
+    /**
+     * @param array<null|bool|int|string|float|Stringable|BackedEnum> $items
+     * @param non-empty-string                                        $separator
+     */
+    public static function implode(iterable $items, string $separator = ','): string
+    {
+        $result = [];
+        foreach ($items as $item) {
+            if ($item instanceof BackedEnum) {
+                $result[] = $item->value;
+            } else {
+                $result[] = (string)$item;
+            }
+        }
+
+        return implode($separator, $result);
     }
 
     /**

--- a/tests/Mock/MockStringBackedEnum.php
+++ b/tests/Mock/MockStringBackedEnum.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Utils\Tests\Mock;
+
+enum MockStringBackedEnum: string
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+}

--- a/tests/Unit/ArraysTest.php
+++ b/tests/Unit/ArraysTest.php
@@ -410,4 +410,11 @@ class ArraysTest extends TestCase
         static::assertSame('foo:bar', Arrays::implode([new MockStringable('foo'), new MockStringable('bar')], ':'));
         static::assertSame('foo:bar', Arrays::implode(MockStringBackedEnum::cases(), ':'));
     }
+
+    public function testImplodeWithEmptySeparator(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Separator cannot be empty');
+        Arrays::implode(['foo', 'bar'], ''); // @phpstan-ignore-line
+    }
 }

--- a/tests/Unit/ArraysTest.php
+++ b/tests/Unit/ArraysTest.php
@@ -7,6 +7,8 @@ use ArrayIterator;
 use DR\Utils\Arrays;
 use DR\Utils\Tests\Mock\MockComparable;
 use DR\Utils\Tests\Mock\MockEquatable;
+use DR\Utils\Tests\Mock\MockStringable;
+use DR\Utils\Tests\Mock\MockStringBackedEnum;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -395,5 +397,16 @@ class ArraysTest extends TestCase
         ];
 
         static::assertSame(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'], Arrays::flatten($input));
+    }
+
+    public function testImplode(): void
+    {
+        static::assertSame('', Arrays::implode([], ':'));
+        static::assertSame('1:2', Arrays::implode([1, 2], ':'));
+        static::assertSame('1:', Arrays::implode([true, false], ':'));
+        static::assertSame('1.2:3.4', Arrays::implode([1.2, 3.4], ':'));
+        static::assertSame('foo:bar', Arrays::implode(['foo', 'bar'], ':'));
+        static::assertSame('foo:bar', Arrays::implode([new MockStringable('foo'), new MockStringable('bar')], ':'));
+        static::assertSame('foo:bar', Arrays::implode(MockStringBackedEnum::cases(), ':'));
     }
 }

--- a/tests/Unit/ArraysTest.php
+++ b/tests/Unit/ArraysTest.php
@@ -406,6 +406,7 @@ class ArraysTest extends TestCase
         static::assertSame('1:', Arrays::implode([true, false], ':'));
         static::assertSame('1.2:3.4', Arrays::implode([1.2, 3.4], ':'));
         static::assertSame('foo:bar', Arrays::implode(['foo', 'bar'], ':'));
+        static::assertSame('foo:bar', Arrays::implode(new ArrayIterator(['foo', 'bar']), ':'));
         static::assertSame('foo:bar', Arrays::implode([new MockStringable('foo'), new MockStringable('bar')], ':'));
         static::assertSame('foo:bar', Arrays::implode(MockStringBackedEnum::cases(), ':'));
     }


### PR DESCRIPTION
Adds `Arrays::implode` to implode an array like normal, but with support for `iterables` and allows BackedEnum as value.

Example:
```php
implode(BackedEnum::cases(), ':');
```