### PR TITLE
Add assert is list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.3', '8.4', '8.5']
         composer-flags: ['', '--prefer-lowest']
     steps:
       - uses: actions/checkout@v6
@@ -64,7 +64,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.3
           coverage: none
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.3-8892BF)](https://php.net/)
 
 ## DR Utility Classes
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Fluent assertion methods, inspired by `webmozart/assert`:
 - `null`
 - `notNull`
 - `isArray`
+- `isList`
 - `inArray`
 - `isCallable`
 - `resource`

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.3"
     },
     "require-dev": {
         "digitalrevolution/phpunit-file-coverage-inspection": "^3.0",
@@ -34,7 +34,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^10.2 || ^11.0 || ^12.0 || ^13.0",
+        "phpunit/phpunit": "^12.0 || ^13.0",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^4.0"
     },

--- a/extension.neon
+++ b/extension.neon
@@ -12,6 +12,10 @@ services:
         tags:
             - phpstan.broker.dynamicStaticMethodReturnTypeExtension
     -
+        class: DR\Utils\PHPStan\Extension\AssertIsListReturnExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
+    -
         class: DR\Utils\PHPStan\Extension\AssertTypeTypeSpecifyingExtension
         tags:
             - phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -81,6 +81,19 @@ class Assert
     }
 
     /**
+     * Assert value is array list
+     * @return list<mixed>
+     */
+    public static function isList(mixed $value, ?string $message = null): array
+    {
+        if (is_array($value) === false || array_is_list($value) === false) {
+            throw ExceptionFactory::createException('a list', $value, $message);
+        }
+
+        return $value;
+    }
+
+    /**
      * Assert value is callable
      * @template       T
      * @phpstan-assert callable $value
@@ -318,6 +331,7 @@ class Assert
     /**
      * Assert value is at least one of the given types
      * @template T
+     *
      * @param T        $value
      * @param string[] $types
      *
@@ -334,7 +348,6 @@ class Assert
 
     /**
      * Assert value is a class-string
-     *
      * @template       T
      * @phpstan-assert class-string $value
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -83,11 +83,11 @@ class Assert
     /**
      * Assert value is array list
      * @template T
-     * @phpstan-assert T&list<value-of<T>> $value
+     * @phpstan-assert T&list<mixed> $value
      *
      * @param T                            $value
      *
-     * @return T&list<value-of<T>>
+     * @return T&list<mixed>
      */
     public static function isList(mixed $value, ?string $message = null): array
     {

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -82,8 +82,12 @@ class Assert
 
     /**
      * Assert value is array list
-     * @phpstan-assert list<mixed> $value
-     * @return list<mixed>
+     * @template T
+     * @phpstan-assert T&list<value-of<T>> $value
+     *
+     * @param T                            $value
+     *
+     * @return T&list<value-of<T>>
      */
     public static function isList(mixed $value, ?string $message = null): array
     {

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -82,6 +82,7 @@ class Assert
 
     /**
      * Assert value is array list
+     * @phpstan-assert list<mixed> $value
      * @return list<mixed>
      */
     public static function isList(mixed $value, ?string $message = null): array

--- a/src/PHPStan/Extension/AssertIsListReturnExtension.php
+++ b/src/PHPStan/Extension/AssertIsListReturnExtension.php
@@ -18,9 +18,6 @@ use PHPStan\Type\TypeCombinator;
 
 /**
  * Extension to ensure the array is narrowed to list<V> while preserving value type information
- * <code>
- *     Assert::isList();
- * </code>
  */
 class AssertIsListReturnExtension implements DynamicStaticMethodReturnTypeExtension
 {

--- a/src/PHPStan/Extension/AssertIsListReturnExtension.php
+++ b/src/PHPStan/Extension/AssertIsListReturnExtension.php
@@ -17,7 +17,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
 /**
- * Extension to ensure the array is narrowed to list<V> while preserving value type information
+ * Extension to ensure Arrays::isList the array is narrowed to list<V> while preserving value type information
  */
 class AssertIsListReturnExtension implements DynamicStaticMethodReturnTypeExtension
 {

--- a/src/PHPStan/Extension/AssertIsListReturnExtension.php
+++ b/src/PHPStan/Extension/AssertIsListReturnExtension.php
@@ -26,13 +26,15 @@ class AssertIsListReturnExtension implements DynamicStaticMethodReturnTypeExtens
         return Assert::class;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public function isStaticMethodSupported(MethodReflection $methodReflection): bool
     {
         return $methodReflection->getName() === 'isList';
     }
 
     /**
-     * @codeCoverageIgnore
      * @inheritDoc
      */
     public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type

--- a/src/PHPStan/Extension/AssertIsListReturnExtension.php
+++ b/src/PHPStan/Extension/AssertIsListReturnExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Utils\PHPStan\Extension;
+
+use DR\Utils\Arrays;
+use DR\Utils\Assert;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Extension to ensure the array is narrowed to list<V> while preserving value type information
+ * <code>
+ *     Assert::isList();
+ * </code>
+ */
+class AssertIsListReturnExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Assert::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'isList';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type
+    {
+        $arg       = Arrays::first($methodCall->getArgs());
+        $valueType = $scope->getType($arg->value)->getIterableValueType();
+
+        return TypeCombinator::intersect(new ArrayType(new IntegerType(), $valueType), new AccessoryArrayListType());
+    }
+}

--- a/src/PHPStan/Extension/AssertIsListReturnExtension.php
+++ b/src/PHPStan/Extension/AssertIsListReturnExtension.php
@@ -26,9 +26,6 @@ class AssertIsListReturnExtension implements DynamicStaticMethodReturnTypeExtens
         return Assert::class;
     }
 
-    /**
-     * @codeCoverageIgnore
-     */
     public function isStaticMethodSupported(MethodReflection $methodReflection): bool
     {
         return $methodReflection->getName() === 'isList';

--- a/src/PHPStan/Extension/AssertIsListReturnExtension.php
+++ b/src/PHPStan/Extension/AssertIsListReturnExtension.php
@@ -32,6 +32,7 @@ class AssertIsListReturnExtension implements DynamicStaticMethodReturnTypeExtens
     }
 
     /**
+     * @codeCoverageIgnore
      * @inheritDoc
      */
     public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type

--- a/tests/Integration/PHPStan/AssertIsListExtensionTest.php
+++ b/tests/Integration/PHPStan/AssertIsListExtensionTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Utils\Tests\Integration\PHPStan;
+
+use DR\Utils\Assert;
+use DR\Utils\PHPStan\Extension\AssertIsListReturnExtension;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(AssertIsListReturnExtension::class)]
+class AssertIsListExtensionTest extends TypeInferenceTestCase
+{
+    public function testFileAsserts(): void
+    {
+        $results = self::gatherAssertTypes(__DIR__ . '/data/AssertIsListAssertions.php');
+        foreach ($results as $result) {
+            $assertType = Assert::string(array_shift($result));
+            $file       = Assert::string(array_shift($result));
+            $this->assertFileAsserts($assertType, $file, ...$result);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [dirname(__DIR__, 3) . '/extension.neon'];
+    }
+}

--- a/tests/Integration/PHPStan/data/AssertIsListAssertions.php
+++ b/tests/Integration/PHPStan/data/AssertIsListAssertions.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Utils\Tests\Integration\PHPStan\data;
+
+use DR\Utils\Assert;
+
+use function PHPStan\Testing\assertType;
+
+class AssertIsListAssertions
+{
+    public function assertions(): void
+    {
+        // constant array preserves value type
+        assertType("list<1|2|3>", Assert::isList([1, 2, 3]));
+        assertType("list<'a'|'b'|'c'>", Assert::isList(['a', 'b', 'c']));
+        assertType("list<1|'foo'>", Assert::isList([1, 'foo']));
+
+        // typed array variable preserves value type, drops key type
+        /** @var array<string, int> $assocInt */
+        $assocInt = [];
+        assertType("list<int>", Assert::isList($assocInt));
+
+        /** @var array<int, string> $indexedString */
+        $indexedString = [];
+        assertType("list<string>", Assert::isList($indexedString));
+
+        /** @var array<int, int|float|string|object|null> $mixedData */
+        $mixedData = [];
+        assertType("list<float|int|object|string|null>", Assert::isList($mixedData));
+
+        // mixed input falls back to list<mixed>
+        /** @var mixed $mixed */
+        $mixed = null;
+        assertType("list<mixed>", Assert::isList($mixed));
+    }
+}

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -56,6 +56,25 @@ class AssertTest extends TestCase
         static::assertSame($objects, Assert::isArray($objects));
     }
 
+    public function testIsList(): void
+    {
+        static::assertSame([1, 'b', 'c'], Assert::isList([1, 'b', 'c']));
+    }
+
+    public function testIsListFailureOnNonArray(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Expecting value to be a list, `foobar (string)` was given');
+        Assert::isList('foobar');
+    }
+
+    public function testIsListFailureOnNonListArray(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Expecting value to be a list, `array` was given');
+        Assert::isList(['key' => 'value']);
+    }
+
     public function testIsCallable(): void
     {
         $callable = [$this, 'testIsCallable'];

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -65,14 +65,14 @@ class AssertTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expecting value to be a list, `foobar (string)` was given');
-        Assert::isList('foobar');
+        Assert::isList('foobar'); // @phpstan-ignore-line
     }
 
     public function testIsListFailureOnNonListArray(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expecting value to be a list, `array` was given');
-        Assert::isList(['key' => 'value']);
+        Assert::isList(['key' => 'value']); // @phpstan-ignore-line
     }
 
     public function testIsCallable(): void

--- a/tests/Unit/PHPStan/Extension/AssertIsListReturnExtensionTest.php
+++ b/tests/Unit/PHPStan/Extension/AssertIsListReturnExtensionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Utils\Tests\Unit\PHPStan\Extension;
+
+use DR\Utils\Assert;
+use DR\Utils\PHPStan\Extension\AssertIsListReturnExtension;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AssertIsListReturnExtension::class)]
+class AssertIsListReturnExtensionTest extends TestCase
+{
+    public function testGetClass(): void
+    {
+        $extension = new AssertIsListReturnExtension();
+        self::assertSame(Assert::class, $extension->getClass());
+    }
+}


### PR DESCRIPTION
Adds `Assert::isList` to assert an array is of type `list<mixed>`

Added phpstan extension to preserve value type information, as this was not possible with phpstan standard docblock notation.

## Scenarios:
- in: `mixed`,  out: `list<mixed>`
- in: `int[]`, out: `list<int>`
- in: `array<int|string..>`, out: `list<int|string..>`

## Security advisories
Had to remove PHPUnit 10 + 11 due to:

Root composer.json requires phpunit/phpunit ^10.2 || ^11.0, found phpunit/phpunit[10.2.0, ..., 10.5.63, 11.0.0, ..., 11.5.55] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-5jz8-6tcw-pbk4") to the audit "ignore" config.
